### PR TITLE
Remove #if

### DIFF
--- a/src/Vectron.Ansi/AnsiHelper.Cursor.RegexShim.cs
+++ b/src/Vectron.Ansi/AnsiHelper.Cursor.RegexShim.cs
@@ -5,7 +5,6 @@ namespace Vectron.Ansi;
 /// </summary>
 public static partial class AnsiHelper
 {
-#if NET7_0_OR_GREATER
     /// <summary>
     /// Find al ANSI cursor escape codes.
     /// </summary>
@@ -15,19 +14,4 @@ public static partial class AnsiHelper
         options: System.Text.RegularExpressions.RegexOptions.None,
         matchTimeoutMilliseconds: 1000)]
     public static partial System.Text.RegularExpressions.Regex MatchCursorEscapeSequence();
-#else
-
-    private static readonly System.Text.RegularExpressions.Regex MatchCursorEscapeSequenceRegex = new(
-        @"\x1B\[[0-9;]*[A-Ga-g]",
-        System.Text.RegularExpressions.RegexOptions.Compiled,
-        TimeSpan.FromSeconds(1));
-
-    /// <summary>
-    /// Find al ANSI cursor escape codes.
-    /// </summary>
-    /// <returns>The compiled regex for matching.</returns>
-    public static System.Text.RegularExpressions.Regex MatchCursorEscapeSequence()
-        => MatchCursorEscapeSequenceRegex;
-
-#endif
 }


### PR DESCRIPTION
#### PR Classification
Code cleanup and modernization to target .NET 7.0 or greater.

#### PR Summary
This pull request removes legacy conditional compilation and simplifies the handling of ANSI cursor escape code regex generation by relying solely on .NET 7.0+ features.
- AnsiHelper.Cursor.RegexShim.cs: Removed #if NET7_0_OR_GREATER conditional logic and manual Regex construction, retaining only the [GeneratedRegex] source-generated method.
